### PR TITLE
Fix inconsistent http.StatusCode in http.Status

### DIFF
--- a/src/net/http/response.go
+++ b/src/net/http/response.go
@@ -174,6 +174,7 @@ func ReadResponse(r *bufio.Reader, req *Request) (*Response, error) {
 	statusCode := resp.Status
 	if i := strings.IndexByte(resp.Status, ' '); i != -1 {
 		statusCode = resp.Status[:i]
+		resp.Status = resp.Status[i:]
 	}
 	if len(statusCode) != 3 {
 		return nil, badStringError("malformed HTTP status code", statusCode)


### PR DESCRIPTION
In the case of parsing HTTP status with a message, eg: `HTTP/1.1 200 OK`,  `StatusCode` is correctly set to `200` but `Status` is parsed to `200 OK` when it should only be `OK`. This leads to inconsistency with `http.StatusText` which only returns `OK` instead of `200 OK`.

In the case `Status` includes a space, it includes a numeric status code we can trim out the numeral and move it to `StatusCode`

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
